### PR TITLE
sanitize curly quotes in meeting name when building search index

### DIFF
--- a/src/components/Meeting.tsx
+++ b/src/components/Meeting.tsx
@@ -22,7 +22,7 @@ import {
   useI18n,
   useInput,
   sanitizeQuotes
-} from '../helpers';
+  } from '../helpers';
 
 export function Meeting({
   link,
@@ -70,7 +70,7 @@ export function Meeting({
   }
 
   const title = input.searchWords?.length ? (
-    <Highlighter searchWords={input.searchWords} textToHighlight={name} sanatize={sanitizeQuotes}/>
+    <Highlighter searchWords={input.searchWords} textToHighlight={name} sanitize={sanitizeQuotes}/>
   ) : (
     name
   );

--- a/src/components/Meeting.tsx
+++ b/src/components/Meeting.tsx
@@ -20,7 +20,8 @@ import {
   formatTime,
   useData,
   useI18n,
-  useInput
+  useInput,
+  sanitizeQuotes
 } from '../helpers';
 
 export function Meeting({
@@ -69,7 +70,7 @@ export function Meeting({
   }
 
   const title = input.searchWords?.length ? (
-    <Highlighter searchWords={input.searchWords} textToHighlight={name} />
+    <Highlighter searchWords={input.searchWords} textToHighlight={name} sanatize={sanitizeQuotes}/>
   ) : (
     name
   );

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -9,3 +9,4 @@ export * from './input';
 export * from './load';
 export * from './theme';
 export * from './types';
+export * from './stringUtils';

--- a/src/helpers/input.ts
+++ b/src/helpers/input.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 
 import { defaultLanguage, Language } from './i18n';
+import { sanitizeQuotes } from './stringUtils';
 
 export type InputType = {
   language: Language;
@@ -28,7 +29,7 @@ export const useInput = () => useContext(Input);
 
 export function parseSearchWords(search?: string) {
   if (!search) return [];
-  return search
+  return sanitizeQuotes(search)
     .toLocaleLowerCase()
     .split(' ')
     .map(term => term.trim())

--- a/src/helpers/load.ts
+++ b/src/helpers/load.ts
@@ -244,10 +244,3 @@ function validateUrl(url?: string) {
 function warn(value: string, type: string, line: number) {
   console.warn(`Row ${line + 2}: “${value}” is not a valid ${type}.`);
 }
-
-// helper to replace curly quotes with straight ones
-export function sanitizeQuotes(str: string): string {
-  return str
-    .replace(/[‘’‛‚]/g, "'") // curly single quotes
-    .replace(/[“”„‟]/g, '"'); // curly double quotes
-}

--- a/src/helpers/load.ts
+++ b/src/helpers/load.ts
@@ -170,15 +170,8 @@ export async function load(url: string, language: Language): Promise<DataType> {
       ...meetingFormats
     ];
 
-    // helper to replace curly quotes with straight ones
-    function removeCurlyQuotes(str: string): string {
-      return str
-        .replace(/[‘’‛‚]/g, "'") // curly single quotes
-        .replace(/[“”„‟]/g, '"'); // curly double quotes
-    }
-
     // add words to search index
-    meeting.search = removeCurlyQuotes(meeting.name)
+    meeting.search = sanitizeQuotes(meeting.name)
       .toLowerCase()
       .split(' ')
       .filter(e => e)
@@ -250,4 +243,11 @@ function validateUrl(url?: string) {
 
 function warn(value: string, type: string, line: number) {
   console.warn(`Row ${line + 2}: “${value}” is not a valid ${type}.`);
+}
+
+// helper to replace curly quotes with straight ones
+export function sanitizeQuotes(str: string): string {
+  return str
+    .replace(/[‘’‛‚]/g, "'") // curly single quotes
+    .replace(/[“”„‟]/g, '"'); // curly double quotes
 }

--- a/src/helpers/load.ts
+++ b/src/helpers/load.ts
@@ -170,8 +170,15 @@ export async function load(url: string, language: Language): Promise<DataType> {
       ...meetingFormats
     ];
 
+    // helper to replace curly quotes with straight ones
+    function removeCurlyQuotes(str: string): string {
+      return str
+        .replace(/[‘’‛‚]/g, "'") // curly single quotes
+        .replace(/[“”„‟]/g, '"'); // curly double quotes
+    }
+
     // add words to search index
-    meeting.search = meeting.name
+    meeting.search = removeCurlyQuotes(meeting.name)
       .toLowerCase()
       .split(' ')
       .filter(e => e)

--- a/src/helpers/load.ts
+++ b/src/helpers/load.ts
@@ -6,6 +6,7 @@ import { DataType } from './data';
 import { Language } from './i18n';
 import * as languageStrings from '../languages';
 import type { Group, JSONRow, Meeting } from './types';
+import { sanitizeQuotes } from './stringUtils';
 
 export async function load(url: string, language: Language): Promise<DataType> {
   const { strings } = languageStrings[language];

--- a/src/helpers/stringUtils.ts
+++ b/src/helpers/stringUtils.ts
@@ -1,0 +1,5 @@
+export function sanitizeQuotes(str: string): string {
+    return str
+      .replace(/[‘’‛‚]/g, "'")
+      .replace(/[“”„‟]/g, '"');
+  }  


### PR DESCRIPTION
I went with the simplest approach. I don't like however that
   - the browser doesn't highlight  /What’s/ when searching for /What's/
   - curly version of /what’s/ isn't added to index as well as non-curly /what's/